### PR TITLE
feat: add missing versionless OpenAPI routes

### DIFF
--- a/specification/protocol/open_inference_rest.yaml
+++ b/specification/protocol/open_inference_rest.yaml
@@ -52,13 +52,30 @@ paths:
         in: path
         required: true
     get:
-      summary: Model Ready
+      summary: Model Version Ready
       tags: []
       responses:
         '200':
           description: OK
       operationId: check-model-version-readiness
-      description: The “model ready” health API indicates if a specific model is ready for inferencing. The model name and (optionally) version must be available in the URL. If a version is not provided the server may choose a version based on its own policies.
+      description: The "model ready" health API indicates if a specific model is ready for inferencing. The model name and version must be provided in the URL.
+  '/v2/models/{MODEL_NAME}/ready':
+    parameters:
+      - schema:
+          type: string
+        name: MODEL_NAME
+        in: path
+        required: true
+    get:
+      summary: Model Ready
+      tags: []
+      responses:
+        '200':
+          description: OK
+      operationId: check-model-readiness
+      description: >
+        The "model ready" health API indicates if a specific model is ready for inferencing.
+        The model name is provided in the URL. The server may choose a model version based on its own policies.
   /v2/:
     get:
       summary: Server Metadata
@@ -77,7 +94,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/metadata_server_error_response'
       operationId: read-server-metadata
-      description: 'The server metadata endpoint provides information about the server. A server metadata request is made with an HTTP GET to a server metadata endpoint. In the corresponding response the HTTP body contains the [Server Metadata Response JSON Object](#server-metadata-response-json-object) or the [Server Metadata Response JSON Error Object](#server-metadata-response-json-error-object).'
+      description: >
+        The server metadata endpoint provides information about the server.
+        Compliant servers return a [Server Metadata Response JSON Object](#server-metadata-response-json-object) or a [Server Metadata Response JSON Error Object](#server-metadata-response-json-error-object).
   '/v2/models/{MODEL_NAME}/versions/{MODEL_VERSION}':
     parameters:
       - schema:
@@ -91,7 +110,7 @@ paths:
         in: path
         required: true
     get:
-      summary: Model Metadata
+      summary: Model Version Metadata
       tags: []
       responses:
         '200':
@@ -101,7 +120,32 @@ paths:
               schema:
                 $ref: '#/components/schemas/metadata_model_response'
       operationId: read-model-version-metadata
-      description: 'The per-model metadata endpoint provides information about a model. A model metadata request is made with an HTTP GET to a model metadata endpoint. In the corresponding response the HTTP body contains the [Model Metadata Response JSON Object](#model-metadata-response-json-object) or the [Model Metadata Response JSON Error Object](#model-metadata-response-json-error-object). The model name and (optionally) version must be available in the URL. If a version is not provided the server may choose a version based on its own policies or return an error.'
+      description: >
+        The per-model metadata endpoint provides information about a model.
+        Compliant servers return a [Model Metadata Response JSON Object](#model-metadata-response-json-object) or a [Model Metadata Response JSON Error Object](#model-metadata-response-json-error-object).
+        The model name and version must be provided in the URL.
+  '/v2/models/{MODEL_NAME}':
+    parameters:
+      - schema:
+          type: string
+        name: MODEL_NAME
+        in: path
+        required: true
+    get:
+      summary: Model Metadata
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/metadata_model_response'
+      operationId: read-model-metadata
+      description: >
+        The per-model metadata endpoint provides information about a model.
+        Compliant servers return a [Model Metadata Response JSON Object](#model-metadata-response-json-object) or a [Model Metadata Response JSON Error Object](#model-metadata-response-json-error-object).
+        The model name is provided in the URL. The server may choose a model version based on its own policies or return an error.
   '/v2/models/{MODEL_NAME}/versions/{MODEL_VERSION}/infer':
     parameters:
       - schema:
@@ -135,7 +179,44 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/inference_request'
-      description: 'An inference request is made with an HTTP POST to an inference endpoint. In the request the HTTP body contains the [Inference Request JSON Object](#inference-request-json-object). In the corresponding response the HTTP body contains the [Inference Response JSON Object](#inference-response-json-object) or [Inference Response JSON Error Object](#inference-response-json-error-object). See [Inference Request Examples](#inference-request-examples) for some example HTTP/REST requests and responses.'
+      description: >
+        An inference request is made with an HTTP POST to an inference endpoint.
+        Compliant servers return an [Inference Response JSON Object](#inference-response-json-object) or an [Inference Response JSON Error Object](#inference-response-json-error-object).
+        See [Inference Request Examples](#inference-request-examples) for some example HTTP/REST requests and responses.
+        The model name and version must be provided in the URL.
+  '/v2/models/{MODEL_NAME}/infer':
+    parameters:
+      - schema:
+          type: string
+        name: MODEL_NAME
+        in: path
+        required: true
+    post:
+      summary: Inference
+      operationId: model-infer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/inference_response'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/inference_error_response'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/inference_request'
+      description: >
+        An inference request is made with an HTTP POST to an inference endpoint.
+        Compliant servers return an [Inference Response JSON Object](#inference-response-json-object) or an [Inference Response JSON Error Object](#inference-response-json-error-object).
+        See [Inference Request Examples](#inference-request-examples) for some example HTTP/REST requests and responses.
+        The model name is provided in the URL. The server may choose a model version based on its own policies or return an error.
 components:
   schemas:
     metadata_server_response:

--- a/specification/protocol/open_inference_rest.yaml
+++ b/specification/protocol/open_inference_rest.yaml
@@ -180,10 +180,11 @@ paths:
             schema:
               $ref: '#/components/schemas/inference_request'
       description: >
-        An inference request is made with an HTTP POST to an inference endpoint.
+        Send data to a model for inferencing via an [Inference Request JSON Object](#inference-request-json-object).
         Compliant servers return an [Inference Response JSON Object](#inference-response-json-object) or an [Inference Response JSON Error Object](#inference-response-json-error-object).
-        See [Inference Request Examples](#inference-request-examples) for some example HTTP/REST requests and responses.
         The model name and version must be provided in the URL.
+
+        See [Inference Request Examples](#inference-request-examples) for some example HTTP/REST requests and responses.
   '/v2/models/{MODEL_NAME}/infer':
     parameters:
       - schema:
@@ -213,10 +214,11 @@ paths:
             schema:
               $ref: '#/components/schemas/inference_request'
       description: >
-        An inference request is made with an HTTP POST to an inference endpoint.
+        Send data to a model for inferencing via an [Inference Request JSON Object](#inference-request-json-object).
         Compliant servers return an [Inference Response JSON Object](#inference-response-json-object) or an [Inference Response JSON Error Object](#inference-response-json-error-object).
-        See [Inference Request Examples](#inference-request-examples) for some example HTTP/REST requests and responses.
         The model name is provided in the URL. The server may choose a model version based on its own policies or return an error.
+
+        See [Inference Request Examples](#inference-request-examples) for some example HTTP/REST requests and responses.
 components:
   schemas:
     metadata_server_response:


### PR DESCRIPTION
Our [OpenAPI specification docs](https://github.com/open-inference/open-inference-protocol/blob/7024882f746aadc188192c63d10399b779401dea/specification/protocol/inference_rest.md) describe path components for various operations as being optional:

> | API  | Verb | Path |
> | ------------- | ------------- | ------------- | 
> | Inference | POST | v2/models/<model_name>[/versions/\<model_version\>]/infer | 
> | Model Metadata | GET | v2/models/\<model_name\>[/versions/\<model_version\>] | 
> | Server Ready | GET | v2/health/ready | 
> | Server Live | GET | v2/health/live |
> | Server Metadata | GET | v2 | 
> | Model Ready| GET   | v2/models/\<model_name\>[/versions/<model_version>]/ready |  
> 
> ** path contents in `[]` are optional

This PR adds these optional routes to the openapi spec, since path parameters are [non-optional as per the openapi spec](https://spec.openapis.org/oas/v3.1.0#fixed-fields-9:~:text=Determines%20whether%20this%20parameter%20is%20mandatory.%20If%20the%20parameter%20location%20is%20%22path%22%2C%20this%20property%20is%20REQUIRED%20and%20its%20value%20MUST%20be%20true.), but even still the literal `/version/` path component would require this anyway.

Since some operations were added, descriptions for the original and new operations have been updated.