### PR TITLE
fix: make rpc model version optional

### DIFF
--- a/specification/protocol/open_inference_grpc.proto
+++ b/specification/protocol/open_inference_grpc.proto
@@ -67,7 +67,7 @@ message ModelReadyRequest
 
   // The version of the model to check for readiness. If not given the
   // server will choose a version based on the model and internal policy.
-  string version = 2;
+  optional string version = 2;
 }
 
 message ModelReadyResponse
@@ -97,7 +97,7 @@ message ModelMetadataRequest
 
   // The version of the model to check for readiness. If not given the
   // server will choose a version based on the model and internal policy.
-  string version = 2;
+  optional string version = 2;
 }
 
 message ModelMetadataResponse
@@ -173,7 +173,7 @@ message ModelInferRequest
 
   // The version of the model to use for inference. If not given the
   // server will choose a version based on the model and internal policy.
-  string model_version = 2;
+  optional string model_version = 2;
 
   // Optional identifier for the request. If specified will be
   // returned in the response.


### PR DESCRIPTION
Adds the [`optional` field label](https://protobuf.dev/programming-guides/proto3/#field-labels) to model metadata, version, and inference requests in the RPC specification to match our documentation.

Other fields in the RPC spec seem to be presenting as optional, but those can be addressed in other issues and PRs.


Closes #1 