### PR TITLE
fix: define empty openAPI security to signal protocol has no preference

### DIFF
--- a/specification/protocol/open_inference_rest.yaml
+++ b/specification/protocol/open_inference_rest.yaml
@@ -21,6 +21,7 @@ info:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0'
 servers: []
+security: []
 paths:
   /v2/health/live:
     get:


### PR DESCRIPTION
Previous CI jobs had been failing because of a default linting rule from redocly that required the openAPI document to declare a security model. Being a protocol reference, open-inference-protocol has no stance on how a given model server implements their security. I thought this was going to be more tricky to declare through the spec while still making the linter rule happy. Just adding an empty security scheme declaration seems to be the way to go. If downstream implementations want to extend this spec, they can do so with JSON Schema extensions: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#document-structure

Closes #7 