### PR TITLE
revert: #12 - use linter silencing instead

### DIFF
--- a/.redocly.lint-ignore.yaml
+++ b/.redocly.lint-ignore.yaml
@@ -6,19 +6,13 @@ specification/protocol/open_inference_rest.yaml:
   operation-4xx-response:
     - '#/paths/~1v2~1health~1live/get/responses'
     - '#/paths/~1v2~1health~1ready/get/responses'
-    - >-
-      #/paths/~1v2~1models~1${MODEL_NAME}~1versions~1${MODEL_VERSION}~1ready/get/responses
-    - >-
-      #/paths/~1v2~1models~1${MODEL_NAME}~1versions~1${MODEL_VERSION}/get/responses
-  no-path-trailing-slash:
-    - '#/paths/~1v2~1'
-  no-unused-components:
-    - '#/components/schemas/metadata_model_error_response'
   security-defined:
+    - '#/paths/~1v2/get'
     - '#/paths/~1v2~1health~1live/get'
     - '#/paths/~1v2~1health~1ready/get'
-    - '#/paths/~1v2~1models~1${MODEL_NAME}~1versions~1${MODEL_VERSION}~1ready/get'
-    - '#/paths/~1v2~1/get'
-    - '#/paths/~1v2~1models~1${MODEL_NAME}~1versions~1${MODEL_VERSION}/get'
-    - >-
-      #/paths/~1v2~1models~1${MODEL_NAME}~1versions~1${MODEL_VERSION}~1infer/post
+    - '#/paths/~1v2~1models~1{MODEL_NAME}~1ready/get'
+    - '#/paths/~1v2~1models~1{MODEL_NAME}~1versions~1{MODEL_VERSION}~1ready/get'
+    - '#/paths/~1v2~1models~1{MODEL_NAME}/get'
+    - '#/paths/~1v2~1models~1{MODEL_NAME}~1versions~1{MODEL_VERSION}/get'
+    - '#/paths/~1v2~1models~1{MODEL_NAME}~1infer/post'
+    - '#/paths/~1v2~1models~1{MODEL_NAME}~1versions~1{MODEL_VERSION}~1infer/post'

--- a/specification/protocol/open_inference_rest.yaml
+++ b/specification/protocol/open_inference_rest.yaml
@@ -88,7 +88,7 @@ paths:
       description: >
         The "model ready" health API indicates if a specific model is ready for inferencing.
         The model name is provided in the URL. The server may choose a model version based on its own policies.
-  /v2/:
+  /v2:
     get:
       summary: Server Metadata
       tags: []

--- a/specification/protocol/open_inference_rest.yaml
+++ b/specification/protocol/open_inference_rest.yaml
@@ -21,7 +21,6 @@ info:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0'
 servers: []
-security: []
 paths:
   /v2/health/live:
     get:


### PR DESCRIPTION
PR #12 added an empty security definition to signal that the protocol definition has no stance on what security mechanisms client libraries use. This isn't how the spec should work, and was causing issues when generating code in [open-inference/python-clients](https://github.com/open-inference/python-clients). Issue #7 was about addressing the CI linting job, not about changing the spec.