### PR TITLE
chore(openapi): migrate to openapi spec version 3.1.0

### DIFF
--- a/specification/protocol/open_inference_rest.yaml
+++ b/specification/protocol/open_inference_rest.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-openapi: 3.0.0
+openapi: 3.1.0
 info:
   title: Data Plane
   version: '2.0'
@@ -249,7 +249,6 @@ components:
       title: metadata_server_response
       type: object
       description: ''
-      x-examples: {}
       properties:
         name:
           type: string
@@ -325,43 +324,6 @@ components:
     inference_request:
       title: inference_request
       type: object
-      x-examples:
-        Example 1:
-          id: '42'
-          inputs:
-            - name: input0
-              shape:
-                - 2
-                - 2
-              datatype: UINT32
-              data:
-                - 1
-                - 2
-                - 3
-                - 4
-            - name: input1
-              shape:
-                - 3
-              datatype: BOOL
-              data:
-                - true
-          outputs:
-            - name: output0
-        Example 2:
-          id: '42'
-          outputs:
-            - name: output0
-              shape:
-                - 3
-                - 2
-              datatype: FP32
-              data:
-                - 1
-                - 1.1
-                - 2
-                - 2.1
-                - 3
-                - 3.1
       properties:
         id:
           type: string
@@ -379,7 +341,6 @@ components:
         - inputs
     parameters:
       title: parameters
-      x-examples: {}
       type: object
     request_input:
       title: request_input


### PR DESCRIPTION
Migrates the open inference protocol specification to openapi version 3.1.0. 

I followed the upgrade guide posted by openapi: https://www.openapis.org/blog/2021/02/16/migrating-from-openapi-3-0-to-3-1-0

Closes #14 