### PR TITLE
Rename branch master to main in CI lint (kserve/open-inference-protocol#19)

### DIFF
--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -2,7 +2,7 @@ name: "OpenApi lint"
 
 on:
   push:
-    branches: [ master, release* ]
+    branches: [ main, release* ]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Rename branch master to main in CI

Signed-off-by: Sivanantham Chinnaiyan <sivanantham.chinnaiyan@ideas2it.com>
(cherry picked from commit https://github.com/kserve/open-inference-protocol/commit/853da9f23f68905fb4f87e76e018e5345dc36350853da9f23f68905fb4f87e76e018e5345dc36350)